### PR TITLE
Improve mismatched types diagnostic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,25 +53,16 @@ let x: u32 = match Ok::<_, Never>(42) {
 #![no_std]
 #![forbid(unsafe_code)]
 
-/// Workaround for `fn_traits` and/or `unboxed_closures`
 mod fn_traits {
-    pub
-    trait FnOnce<Args> {
+    pub trait FnPtr {
         type Output;
     }
 
-    impl<F, R> FnOnce<()> for F
-    where
-        F : ::core::ops::FnOnce() -> R,
-    {
+    // This has to refer to a specific primitive type. A blanket impl produces bad diagnostics. See #3.
+    impl<R> FnPtr for fn() -> R {
         type Output = R;
     }
 }
 
 /// The `!` type. See [the main docs for more info][`crate`].
-pub
-type Never = <
-    fn() -> !
-    as
-    fn_traits::FnOnce<()>
->::Output;
+pub type Never = <fn() -> ! as fn_traits::FnPtr>::Output;


### PR DESCRIPTION
When a trait `Tr` is implemented for `Never` and the trait solver attempts to resolve `T: Tr`, the old implementation would eventually rewrite the obligation to `fn() -> !: FnOnce<(), Output = T>`, which fails with the following error:

	error[E0271]: expected `fn() -> !` to return `T`, but it returns `!`
	note: required for `fn() -> !` to implement `fn_traits::FnOnce<()>`
	    impl<F, R> FnOnce<()> for F
		       ^^^^^^^^^^     ^
	    where
		F: core::ops::FnOnce() -> R,
					  - unsatisfied trait bound introduced here

This is quite misleading, because `fn() -> !` *does* implement `FnOnce<()>`, just not with the right type; and it differs from how all other type mismatch errors are reported, which is:

	error[E0277]: the trait bound `T: Tr` is not satisfied
	help: the trait `Tr` is implemented for `!`

This commit improves the error message to something very close:

    error[E0277]: the trait bound `T: Tr` is not satisfied
    help: the trait `Tr` is implemented for `<fn() -> ! as FnOutput>::Output`

How often this matters for `never-say-never` is questionable, because `impl Tr for Never` makes implementing the trait for any other type impossible due to coherence. But as `never-say-never` is often refered to as the canonical implementation of the hack, it's probably better to keep it high-quality.